### PR TITLE
[DOOM-16] Fix branch naming discrepancy between CLAUDE.md and git hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,17 +88,17 @@ At the beginning of each Claude Code session, follow these steps:
 **Branch Types:**
 - `feature/` - New features or enhancements
 - `bugfix/` - Bug fixes
-- `hotfix/` - Critical production fixes
-- `chore/` - Maintenance tasks (dependencies, refactoring, tooling)
+- `improvement/` - Improvements to existing features
 - `docs/` - Documentation-only changes
+- `refactor/` - Code refactoring and maintenance tasks (dependencies, cleanup, tooling)
 
 **Examples:**
 ```bash
 feature/DOOM-123-add-dark-mode
 bugfix/DOOM-456-fix-search-highlighting
-hotfix/DOOM-789-critical-rendering-bug
-chore/DOOM-234-update-maven-dependencies
+improvement/DOOM-789-optimize-tree-rendering
 docs/DOOM-567-api-documentation
+refactor/DOOM-234-update-maven-dependencies
 ```
 
 **Rules:**
@@ -106,6 +106,8 @@ docs/DOOM-567-api-documentation
 - Use lowercase with hyphens for readability
 - Keep description short (3-5 words max)
 - Description should be meaningful but concise
+- Use only the branch types listed above (validated by git hooks)
+- For maintenance tasks (dependencies, cleanup, tooling), use `refactor/`
 - Compatible with GitHub Actions validation
 
 ### Implementation Workflow


### PR DESCRIPTION
## Summary
Synchronize branch naming documentation with git hook validation rules.

**Changes:**
- ❌ Removed unsupported types: `hotfix/`, `chore/`
- ✅ Added supported types: `improvement/`, `refactor/`
- Updated all examples to use only validated branch types
- Added clarification: Use `refactor/` for maintenance/cleanup tasks

**Git Hook allows:** feature, bugfix, improvement, docs, refactor
**CLAUDE.md now documents:** feature, bugfix, improvement, docs, refactor

## Problem Fixed
Developers following CLAUDE.md were getting push failures when using `chore/` or `hotfix/` branch types. This caused confusion and required branch renames (as seen in DOOM-15).

## Jira Task
Closes DOOM-16

## Test Plan
- [x] Documentation-only changes (no build required)
- [x] Branch name validated by git hook (docs/ type)
- [x] Commit message validated by git hook
- [x] Agent templates synchronized
- [ ] Manual review: Branch types match git hook validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)